### PR TITLE
Disable ol-prefix rule

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,4 @@
 {
-  "line-length": false
+  "line-length": false,
+  "ol-prefix": false
 }


### PR DESCRIPTION
Ordered list item prefix
See https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md029---ordered-list-item-prefix